### PR TITLE
fix repo task incorrect usage of xml as icons

### DIFF
--- a/buildSrc/src/main/kotlin/RepoTask.kt
+++ b/buildSrc/src/main/kotlin/RepoTask.kt
@@ -83,7 +83,13 @@ open class RepoTask : DefaultTask() {
 
     val (pkgName, vcode, vname) = PACKAGE.find(lines.first())!!.destructured
 
-    val resourceIcon = appResources.first { it.endsWith("type=PNG") && it.contains("xxxhdpi")}.let { it ->  RESOURCE_ICON.find(it)?.value }
+    val resourceIcon = appResources
+      .first { it.endsWith("type=PNG") && it.contains("xxxhdpi")}
+      .let { it ->
+        RESOURCE_ICON.find(it)?.groupValues.let {
+          it?.getOrNull(1)
+        }
+      }
 
     val iconPath = lines.last { it.startsWith("application-icon-") }
       .let { it -> APPLICATION_ICON.find(it)!!.groupValues.let { it[1] } }
@@ -177,7 +183,7 @@ open class RepoTask : DefaultTask() {
     val PACKAGE = Regex("^package: name='([^']+)' versionCode='([0-9]*)' versionName='([^']*)'.*$")
     val METADATA = Regex("^meta-data: name='([^']*)' value='([^']*)")
     val APPLICATION_ICON = Regex("^application-icon-\\d+:'([^']*)'$")
-    val RESOURCE_ICON = Regex("[a-zA-Z]+/[a-zA-Z]+.[a-zA-Z]+")
+    val RESOURCE_ICON = Regex("\\(xxxhdpi\\) \\(file\\) (res/[A-Z]*.png) type=PNG")
   }
 
   private data class Metadata(

--- a/buildSrc/src/main/kotlin/RepoTask.kt
+++ b/buildSrc/src/main/kotlin/RepoTask.kt
@@ -100,7 +100,7 @@ open class RepoTask : DefaultTask() {
     val nsfw = metadata.first { it.name == "source.nsfw" }.value == "1"
 
     return Badging(pkgName, apkFile.name, sourceName, id, lang, vcode.toInt(), vname, description,
-      nsfw, resourceIcon?:iconPath)
+      nsfw, resourceIcon ?: iconPath)
   }
 
   private fun ensureValidState(badgings: List<Badging>) {


### PR DESCRIPTION
The repo task uses xml it if exists in res directory which makes the icons not available in repo build directory.